### PR TITLE
Deprecated Print History Chat

### DIFF
--- a/terminal/chat.go
+++ b/terminal/chat.go
@@ -64,15 +64,3 @@ func (h *ChatHistory) GetHistory() string {
 	// Join the sanitized messages with a newline character
 	return strings.Join(sanitizedMessages, "\n")
 }
-
-// PrintHistory outputs all messages in the chat history to the standard output,
-// one message per line. This method is useful for displaying the chat history
-// directly to the terminal.
-//
-// Each message is printed in the order it was added, preserving the conversation
-// flow. This method does not return any value or error.
-func (h *ChatHistory) PrintHistory() {
-	for _, msg := range h.Messages {
-		fmt.Println(msg)
-	}
-}

--- a/terminal/deprecated.go
+++ b/terminal/deprecated.go
@@ -1,0 +1,18 @@
+package terminal
+
+import "fmt"
+
+// PrintHistory outputs all messages in the chat history to the standard output,
+// one message per line. This method is useful for displaying the chat history
+// directly to the terminal.
+//
+// Each message is printed in the order it was added, preserving the conversation
+// flow. This method does not return any value or error.
+//
+// Deprecated: This method is deprecated was replaced by GetHistory.
+// It used to be used for debugging purposes while made the chat system without storage such as database.
+func (h *ChatHistory) PrintHistory() {
+	for _, msg := range h.Messages {
+		fmt.Println(msg)
+	}
+}


### PR DESCRIPTION
- [+] refactor(chat.go): Remove PrintHistory method from ChatHistory struct
- [+] feat(deprecated.go): Add Deprecated comment to PrintHistory method