### PR TITLE
Better Handling ":quit" Commands

### DIFF
--- a/terminal/commands.go
+++ b/terminal/commands.go
@@ -4,7 +4,6 @@ package terminal
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
@@ -24,6 +23,7 @@ func HandleCommand(input string, session *Session) (bool, error) {
 	if strings.HasPrefix(input, PrefixChar) {
 		switch input {
 		case QuitCommand:
+			fmt.Println() // this is to make the message appear on a new line which better instead of "\n"
 			// Send a message to the AI asking for a shutdown message
 			aiShutdownMessage, err := SendMessage(session.Ctx, session.Client, ContextPromptShutdown)
 			if err != nil {
@@ -36,9 +36,7 @@ func HandleCommand(input string, session *Session) (bool, error) {
 			// Proceed with shutdown
 			fmt.Println(ShutdownMessage)
 			session.Cancel() // Cancel the context to cleanup resources
-			session.Client.Close()
-			os.Exit(0) // Exit the application immediately
-			return true, nil
+			return true, nil // Signal to the main loop that it's time to exit
 		default:
 			fmt.Println(UnknownCommand)
 			return true, nil

--- a/terminal/constant.go
+++ b/terminal/constant.go
@@ -25,6 +25,7 @@ const (
 	ShutdownMessage       = "Shutting down gracefully..."
 	UnknownCommand        = "Unknown command."
 	ContextPromptShutdown = "The user has issued a quit command. Please provide a shutdown message as you are Assistant."
+	ContextCancel         = "Context canceled, shutting down..." // sending a messages to gopher officer
 )
 
 // Defined constants for commands


### PR DESCRIPTION
complex:
```sh
$ gocyclo -avg terminal
5 terminal (*Session).processInput terminal\session.go:108:1
5 terminal Colorize terminal\colorize.go:37:1
4 terminal (*Session).handleUserInput terminal\session.go:138:1
4 terminal (*Session).Start terminal\session.go:62:1
4 terminal printResponse terminal\genai.go:71:1
4 terminal HandleCommand terminal\commands.go:22:1
4 terminal (*ChatHistory).GetHistory terminal\chat.go:47:1
3 terminal CountTokens terminal\token_counter.go:34:1
3 terminal SingleCharColorize terminal\colorize.go:78:1
2 terminal NewSession terminal\session.go:38:1
2 terminal GetEmbedding terminal\genai_embedding.go:38:1
2 terminal SendMessage terminal\genai.go:45:1
2 terminal PrintTypingChat terminal\genai.go:23:1
2 terminal (*ChatHistory).PrintHistory terminal\deprecated.go:14:1
2 terminal (*DebugOrErrorLogger).Debug terminal\debug_or_error.go:37:1
1 terminal (*Session).cleanup terminal\session.go:160:1
1 terminal (*Session).setupSignalHandling terminal\session.go:93:1
1 terminal init terminal\init.go:17:1
1 terminal (*DebugOrErrorLogger).Error terminal\debug_or_error.go:51:1
1 terminal NewDebugOrErrorLogger terminal\debug_or_error.go:24:1
1 terminal (*ChatHistory).AddMessage terminal\chat.go:28:1
Average: 2.57
```
still better