### PR TITLE
Refactor [Terminal] [Commands] Pass Context to End Session

### DIFF
--- a/terminal/commands.go
+++ b/terminal/commands.go
@@ -81,8 +81,8 @@ func handleQuitCommand(session *Session) (bool, error) {
 	// Print only the shutdown message
 	fmt.Println() // A better newline instead of hardcoding "\n"
 	fmt.Println(StripChars)
-	fmt.Println(ShutdownMessage)
-	session.Cancel() // Cancel the context to cleanup resources
+	session.EndSession() // Use EndSession to perform cleanup and signal that the session has ended
+
 	return true, nil // Signal to the main loop that it's time to exit
 }
 
@@ -149,6 +149,6 @@ func handleCheckVersionCommand(session *Session) (bool, error) {
 		fmt.Println() // A better newline instead of hardcoding "\n"
 		fmt.Println(StripChars)
 	}
-
+	session.Ended = true // Signal that the session has ended
 	return false, nil
 }

--- a/terminal/commands.go
+++ b/terminal/commands.go
@@ -81,7 +81,8 @@ func handleQuitCommand(session *Session) (bool, error) {
 	// Print only the shutdown message
 	fmt.Println() // A better newline instead of hardcoding "\n"
 	fmt.Println(StripChars)
-	session.EndSession() // Use EndSession to perform cleanup and signal that the session has ended
+	fmt.Println(ShutdownMessage) // Print the shutdown message
+	session.EndSession()         // Use EndSession to perform cleanup and signal that the session has ended
 
 	return true, nil // Signal to the main loop that it's time to exit
 }


### PR DESCRIPTION
- [+] refactor(commands.go): change session.Cancel() to session.EndSession() for cleanup and signaling session end
- [+] feat(commands.go): add session.Ended flag to signal session end