### PR TITLE
Fix [Terminal] [Commands] Pass Error

### DIFF
--- a/terminal/commands.go
+++ b/terminal/commands.go
@@ -272,6 +272,7 @@ func (cmd *handlepingCommand) Execute(session *Session, parts []string) (bool, e
 	_, err := fun_stuff.PingIP(ip)
 	if err != nil {
 		logger.Error(ErrorPingFailed, err)
+		fmt.Println()
 	}
 
 	return false, nil


### PR DESCRIPTION
- [+] fix(commands.go): add new line after printing error message in handlepingCommand.Execute()

Note: This a better way instead of that hardcoded "\n" lmao