### PR TITLE
Improve Binary Formatting ANSI Colors Code

### DIFF
--- a/terminal/colorize.go
+++ b/terminal/colorize.go
@@ -18,17 +18,6 @@ type ANSIColorCodes struct {
 	ColorReset  string
 }
 
-// colors holds the ANSI color codes and is accessible throughout the package.
-var colors = ANSIColorCodes{
-	ColorRed:    "\x1b[31m",
-	ColorGreen:  "\x1b[32m",
-	ColorYellow: "\x1b[33m",
-	ColorBlue:   "\x1b[34m",
-	ColorPurple: "\x1b[35m",
-	ColorCyan:   "\x1b[36m",
-	ColorReset:  "\x1b[0m",
-}
-
 // ANSI color codes
 const (
 	// Note: By replacing the ANSI escape sequence from "\033" to "\x1b", might can avoid a rare bug that sometimes occurs on different machines,

--- a/terminal/colorize.go
+++ b/terminal/colorize.go
@@ -9,13 +9,15 @@ import (
 
 // ANSI color codes
 const (
-	ColorRed    = "\033[31m"
-	ColorGreen  = "\033[32m"
-	ColorYellow = "\033[33m"
-	ColorBlue   = "\033[34m"
-	ColorPurple = "\033[35m"
-	ColorCyan   = "\033[36m"
-	ColorReset  = "\033[0m"
+	// Note: By replacing the ANSI escape sequence from "\033" to "\x1b", might can avoid a rare bug that sometimes occurs on different machines,
+	// although the original code works fine on mine (Author: @H0llyW00dzZ).
+	ColorRed    = "\x1b[31m"
+	ColorGreen  = "\x1b[32m"
+	ColorYellow = "\x1b[33m"
+	ColorBlue   = "\x1b[34m"
+	ColorPurple = "\x1b[35m"
+	ColorCyan   = "\x1b[36m"
+	ColorReset  = "\x1b[0m"
 )
 
 // Colorize applies ANSI color codes to the text surrounded by specified delimiters.

--- a/terminal/colorize.go
+++ b/terminal/colorize.go
@@ -7,6 +7,28 @@ import (
 	"strings"
 )
 
+// ANSIColorCodes defines a struct for holding ANSI color escape sequences.
+type ANSIColorCodes struct {
+	ColorRed    string
+	ColorGreen  string
+	ColorYellow string
+	ColorBlue   string
+	ColorPurple string
+	ColorCyan   string
+	ColorReset  string
+}
+
+// colors holds the ANSI color codes and is accessible throughout the package.
+var colors = ANSIColorCodes{
+	ColorRed:    "\x1b[31m",
+	ColorGreen:  "\x1b[32m",
+	ColorYellow: "\x1b[33m",
+	ColorBlue:   "\x1b[34m",
+	ColorPurple: "\x1b[35m",
+	ColorCyan:   "\x1b[36m",
+	ColorReset:  "\x1b[0m",
+}
+
 // ANSI color codes
 const (
 	// Note: By replacing the ANSI escape sequence from "\033" to "\x1b", might can avoid a rare bug that sometimes occurs on different machines,
@@ -44,9 +66,9 @@ func Colorize(text string, colorPairs []string, keepDelimiters map[string]bool) 
 		parts := strings.Split(text, delimiter)
 		for j := 1; j < len(parts); j += 2 {
 			if keep, exists := keepDelimiters[delimiter]; exists && keep {
-				parts[j] = color + delimiter + parts[j] + delimiter + ColorReset
+				parts[j] = color + delimiter + parts[j] + delimiter + colors.ColorReset
 			} else {
-				parts[j] = color + parts[j] + ColorReset
+				parts[j] = color + parts[j] + colors.ColorReset
 			}
 		}
 		text = strings.Join(parts, "")
@@ -84,11 +106,11 @@ func SingleCharColorize(text string, delimiter string, color string) string {
 	lines := strings.Split(text, StringNewLine)
 	for _, line := range lines {
 		trimmedLine := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmedLine, string(delimiter)) {
+		if strings.HasPrefix(trimmedLine, delimiter) {
 			// Colorize the delimiter and the following space if it's a list item
 			result.WriteString(color)
-			result.WriteString(string(delimiter))
-			result.WriteString(ColorReset)
+			result.WriteString(trimmedLine[:1])
+			result.WriteString(colors.ColorReset)
 			result.WriteString(trimmedLine[1:])
 		} else {
 			// No coloring needed

--- a/terminal/init.go
+++ b/terminal/init.go
@@ -40,6 +40,17 @@ var buildeR strings.Builder
 
 var aiPrompt string
 
+// colors holds the ANSI color codes and is accessible throughout the package.
+var colors = ANSIColorCodes{
+	ColorRed:    "\x1b[31m",
+	ColorGreen:  "\x1b[32m",
+	ColorYellow: "\x1b[33m",
+	ColorBlue:   "\x1b[34m",
+	ColorPurple: "\x1b[35m",
+	ColorCyan:   "\x1b[36m",
+	ColorReset:  "\x1b[0m",
+}
+
 func init() {
 	// Initialize the logger when the package is imported.
 	logger = NewDebugOrErrorLogger()


### PR DESCRIPTION
- [+] chore(colorize.go): update ANSI escape sequences to use "\x1b" instead of "\033" for better compatibility on different machines