### PR TITLE
Fix [UI] [Terminal] [GenAI] Pass to Ansi Variable

### DIFF
--- a/terminal/genai.go
+++ b/terminal/genai.go
@@ -60,7 +60,7 @@ func printANSISequence(message string, index *int) {
 	*index++ // Move past the escape character.
 
 	// Print the rest of the ANSI sequence until 'm' is encountered.
-	for *index < len(message) && message[*index] != BinaryAnsiSquenseChar {
+	for *index < len(message) && message[*index] != byte(ansichar.BinaryAnsiSquenseChar) {
 		fmt.Printf(humantyping.AnimatedChars, message[*index])
 		*index++ // Move past the current character.
 	}


### PR DESCRIPTION
- [+] fix(terminal/genai.go): change comparison of message[*index] from BinaryAnsiSquenseChar to byte(ansichar.BinaryAnsiSquenseChar)
- [+] refactor(terminal/genai.go): rename printANSISequence function to printAnsiSequence