### PR TITLE
Fix Sanitized Message Truncated "[0m" by Simplicity

### DIFF
--- a/terminal/chat.go
+++ b/terminal/chat.go
@@ -64,7 +64,6 @@ func (h *ChatHistory) AddMessage(user string, text string) {
 func (h *ChatHistory) SanitizeMessage(message string) string {
 	// This better way to sanitize message instead of struct again.
 	// It fix truncated message about color codes.
-	var stringansi = StringAnsi
 
 	// Define patterns to identify ANSI color codes.
 	colorCodePattern := regExp.BinaryRegexAnsi
@@ -74,8 +73,8 @@ func (h *ChatHistory) SanitizeMessage(message string) string {
 	sanitizedMessage := re.ReplaceAllString(message, "")
 
 	// Append a reset ANSI code at the end of the message if it contains color codes.
-	if re.MatchString(message) && !strings.HasSuffix(sanitizedMessage, stringansi) {
-		re.ReplaceAllString(message, "")
+	if re.MatchString(message) && !strings.HasSuffix(sanitizedMessage, ColorReset) {
+		sanitizedMessage += ColorReset
 	}
 
 	// Append a reset ANSI code at the end of the message to ensure default color.

--- a/terminal/chat.go
+++ b/terminal/chat.go
@@ -68,17 +68,12 @@ func (h *ChatHistory) SanitizeMessage(message string) string {
 	// Define patterns to identify ANSI color codes.
 	colorCodePattern := regExp.BinaryRegexAnsi
 
-	// Replace all ANSI color codes with the empty string except for the reset code.
-	re := regexp.MustCompile(colorCodePattern)
-	sanitizedMessage := re.ReplaceAllString(message, "")
+	// Compile the regex pattern just once and store it for reuse.
+	// This is more efficient than compiling the pattern each time the function is called.
+	var ansiRegex = regexp.MustCompile(colorCodePattern)
 
-	// Append a reset ANSI code at the end of the message if it contains color codes.
-	if re.MatchString(message) && !strings.HasSuffix(sanitizedMessage, ColorReset) {
-		sanitizedMessage += ColorReset
-	}
-
-	// Append a reset ANSI code at the end of the message to ensure default color.
-	sanitizedMessage += ColorReset
+	// Remove all ANSI color codes from the message.
+	sanitizedMessage := ansiRegex.ReplaceAllString(message, "")
 
 	return sanitizedMessage
 }

--- a/terminal/chat.go
+++ b/terminal/chat.go
@@ -64,7 +64,7 @@ func (h *ChatHistory) AddMessage(user string, text string) {
 func (h *ChatHistory) SanitizeMessage(message string) string {
 	// This better way to sanitize message instead of struct again.
 	// It fix truncated message about color codes.
-
+	buildeR.Reset() // Reset the builder to clear any previous state.
 	// Define patterns to identify ANSI color codes.
 	colorCodePattern := regExp.BinaryRegexAnsi
 

--- a/terminal/chat.go
+++ b/terminal/chat.go
@@ -64,6 +64,7 @@ func (h *ChatHistory) AddMessage(user string, text string) {
 func (h *ChatHistory) SanitizeMessage(message string) string {
 	// This better way to sanitize message instead of struct again.
 	// It fix truncated message about color codes.
+	var stringansi = StringAnsi
 
 	// Define patterns to identify ANSI color codes.
 	colorCodePattern := regExp.BinaryRegexAnsi
@@ -73,8 +74,8 @@ func (h *ChatHistory) SanitizeMessage(message string) string {
 	sanitizedMessage := re.ReplaceAllString(message, "")
 
 	// Append a reset ANSI code at the end of the message if it contains color codes.
-	if re.MatchString(message) && !strings.HasSuffix(sanitizedMessage, ColorReset) {
-		sanitizedMessage += ColorReset
+	if re.MatchString(message) && !strings.HasSuffix(sanitizedMessage, stringansi) {
+		re.ReplaceAllString(message, "")
 	}
 
 	// Append a reset ANSI code at the end of the message to ensure default color.

--- a/terminal/chat.go
+++ b/terminal/chat.go
@@ -72,6 +72,11 @@ func (h *ChatHistory) SanitizeMessage(message string) string {
 	re := regexp.MustCompile(colorCodePattern)
 	sanitizedMessage := re.ReplaceAllString(message, "")
 
+	// Append a reset ANSI code at the end of the message if it contains color codes.
+	if re.MatchString(message) && !strings.HasSuffix(sanitizedMessage, ColorReset) {
+		sanitizedMessage += ColorReset
+	}
+
 	// Append a reset ANSI code at the end of the message to ensure default color.
 	sanitizedMessage += ColorReset
 

--- a/terminal/chat.go
+++ b/terminal/chat.go
@@ -64,7 +64,7 @@ func (h *ChatHistory) AddMessage(user string, text string) {
 func (h *ChatHistory) SanitizeMessage(message string) string {
 	// This better way to sanitize message instead of struct again.
 	// It fix truncated message about color codes.
-	buildeR.Reset() // Reset the builder to clear any previous state.
+
 	// Define patterns to identify ANSI color codes.
 	colorCodePattern := regExp.BinaryRegexAnsi
 

--- a/terminal/constant.go
+++ b/terminal/constant.go
@@ -131,7 +131,6 @@ const (
 	BinaryAnsiSquenseChar   = 'm'
 	BinaryAnsiSquenseString = "m"
 	BinaryRegexAnsi         = `\x1b\[[0-9;]*m`
-	StringAnsi              = "[0m"
 )
 
 // Defined List of Environment variables

--- a/terminal/constant.go
+++ b/terminal/constant.go
@@ -131,6 +131,7 @@ const (
 	BinaryAnsiSquenseChar   = 'm'
 	BinaryAnsiSquenseString = "m"
 	BinaryRegexAnsi         = `\x1b\[[0-9;]*m`
+	StringAnsi              = "[0m"
 )
 
 // Defined List of Environment variables


### PR DESCRIPTION
> [!NOTE]  
> This boost smoothly