### PR TITLE
Fix [Terminal] [Debug or Error] Formatting Signal Message

### DIFF
--- a/terminal/constant.go
+++ b/terminal/constant.go
@@ -16,7 +16,7 @@ const (
 
 // Defined constants for the terminal package
 const (
-	SignalMessage               = "RReceived an interrupt, shutting down gracefully..."
+	SignalMessage               = " Received an interrupt, shutting down gracefully..." // fix formatting ^C in linux/unix
 	RecoverGopher               = "%sRecovered from panic:%s %s%v%s"
 	ObjectHighLevelString       = "%s %s"  // Catch High level string
 	ObjectTripleHighLevelString = "%%%s%%" // Catch High level triple string

--- a/terminal/debug_or_error.go
+++ b/terminal/debug_or_error.go
@@ -71,8 +71,8 @@ func (l *DebugOrErrorLogger) Error(format string, v ...interface{}) {
 	// Add the error prefix in color
 	errorPrefix := colors.ColorRed + message + colors.ColorReset
 
-	// Print the error prefix without a newline
-	PrintPrefixWithTimeStamp(SYSTEMPREFIX)
+	// Print the error prefix with a timestamp
+	PrintPrefixWithTimeStamp(SYSTEMPREFIX + " ")
 
 	// Simulate typing the error message
 	PrintTypingChat(errorPrefix, TypingDelay)

--- a/terminal/debug_or_error.go
+++ b/terminal/debug_or_error.go
@@ -72,7 +72,7 @@ func (l *DebugOrErrorLogger) Error(format string, v ...interface{}) {
 	errorPrefix := colors.ColorRed + message + colors.ColorReset
 
 	// Print the error prefix with a timestamp
-	PrintPrefixWithTimeStamp(SYSTEMPREFIX + " ")
+	PrintPrefixWithTimeStamp(SYSTEMPREFIX + "")
 
 	// Simulate typing the error message
 	PrintTypingChat(errorPrefix, TypingDelay)


### PR DESCRIPTION
- [+] fix(terminal/constant.go): fix formatting of SignalMessage constant
- [+] fix(terminal/debug_or_error.go): fix error logging to include timestamp