### PR TITLE
Refactor [Terminal] [Safety Command] Reduce Complexity

### DIFF
--- a/terminal/commands_types.go
+++ b/terminal/commands_types.go
@@ -140,7 +140,8 @@ type handleSafetyCommand struct {
 
 // IsValid checks if the safety command is valid based on the input parts.
 func (cmd *handleSafetyCommand) IsValid(parts []string) bool {
-	return len(parts) == 2 && (parts[1] == Low || parts[1] == High || parts[1] == Default)
+	_, valid := safetyLevels[parts[1]]
+	return len(parts) == 2 && valid
 }
 
 // setSafetyLevel updates the safety settings based on the command argument.

--- a/terminal/init.go
+++ b/terminal/init.go
@@ -84,6 +84,13 @@ var safetySetters = map[string]SafetySetter{
 	Default: func(s *SafetySettings) { *s = *DefaultSafetySettings() },
 }
 
+// safetyLevels is a map that defines the valid safety options.
+var safetyLevels = map[string]bool{
+	Low:     true,
+	High:    true,
+	Default: true,
+}
+
 func init() {
 	// Initialize the logger when the package is imported.
 	logger = NewDebugOrErrorLogger()


### PR DESCRIPTION
- [+] chore(commands_types.go): refactor handleSafetyCommand.IsValid method to use safetyLevels map for validation
- [+] chore(init.go): add safetyLevels map to define valid safety options