### PR TITLE
Reorganizing Codebase Without Disrupting Functionality

### DIFF
--- a/terminal/constant.go
+++ b/terminal/constant.go
@@ -197,3 +197,24 @@ const (
 	High             = "high"
 	MonitoringSignal = "Received signal: %v.\n"
 )
+
+// ASCII Art
+const (
+	// NOTE: ' is rune not a string
+	G = 'G'
+	V = 'V'
+	// ASCII slant font
+	_G   = "   ______      ______           ___    ____  "
+	_O   = "  / ____/___  / ____/__  ____  /   |  /  _/  "
+	_GEN = " / / __/ __ \\/ / __/ _ \\/ __ \\/ /| |  / /    "
+	A_   = "/ /_/ / /_/ / /_/ /  __/ / / / ___ |_/ /     "
+	I_   = "\\____/\\____/\\____/\\___/_/ /_/_/  |_/___/     "
+	// Blank Art
+	BLANK_ = "                                      "
+)
+
+// Text
+const (
+	Current_Version = "Current Version: " + CurrentVersion
+	Copyright       = "Copyright (c) 2024 @H0llyW00dzZ"
+)

--- a/terminal/figlet_frontend.go
+++ b/terminal/figlet_frontend.go
@@ -62,35 +62,6 @@ const (
 	Copyright       = "Copyright (c) 2024 @H0llyW00dzZ"
 )
 
-// Define the ASCII patterns for the 'slant' font for the characters
-var asciiPatterns = map[rune][]string{
-	// Figlet in a compiled language, not an interpreted language.
-	// This literally header in your machine lmao.
-	// It so easy implement Header like this in go, also it possible to made it animated drawing/human typing this ascii art
-	// unlike "interpreted language" 🤪
-	G: {
-		_G,
-		_O,
-		_GEN,
-		A_,
-		I_,
-	},
-	V: {
-		BLANK_,
-		BLANK_,
-		BLANK_, // TODO: Implement a notification to display here when a new version is available.
-		//			 For checking the version and viewing the change log, implement the command ":checkversion".
-		Current_Version,
-		Copyright,
-	},
-}
-
-// Define a map for character colors
-var asciiColors = map[rune]string{
-	G: BoldText + colors.ColorHex95b806,
-	V: BoldText + colors.ColorCyan24Bit,
-}
-
 // applyColor applies a color to a given line if the color exists.
 func applyColor(artChar ASCIIArtChar, line string) string {
 	if artChar.Color == "" {

--- a/terminal/figlet_frontend.go
+++ b/terminal/figlet_frontend.go
@@ -41,27 +41,6 @@ func (style ASCIIArtStyle) AddChar(char rune, pattern []string, color string) {
 	style[char] = ASCIIArtChar{Pattern: pattern, Color: color}
 }
 
-// ASCII Art
-const (
-	// NOTE: ' is rune not a string
-	G = 'G'
-	V = 'V'
-	// ASCII slant font
-	_G   = "   ______      ______           ___    ____  "
-	_O   = "  / ____/___  / ____/__  ____  /   |  /  _/  "
-	_GEN = " / / __/ __ \\/ / __/ _ \\/ __ \\/ /| |  / /    "
-	A_   = "/ /_/ / /_/ / /_/ /  __/ / / / ___ |_/ /     "
-	I_   = "\\____/\\____/\\____/\\___/_/ /_/_/  |_/___/     "
-	// Blank Art
-	BLANK_ = "                                      "
-)
-
-// Text
-const (
-	Current_Version = "Current Version: " + CurrentVersion
-	Copyright       = "Copyright (c) 2024 @H0llyW00dzZ"
-)
-
 // applyColor applies a color to a given line if the color exists.
 func applyColor(artChar ASCIIArtChar, line string) string {
 	if artChar.Color == "" {

--- a/terminal/init.go
+++ b/terminal/init.go
@@ -93,6 +93,35 @@ var safetyOptions = map[string]SafetyOption{
 	},
 }
 
+// Define the ASCII patterns for the 'slant' font for the characters
+var asciiPatterns = map[rune][]string{
+	// Figlet in a compiled language, not an interpreted language.
+	// This literally header in your machine lmao.
+	// It so easy implement Header like this in go, also it possible to made it animated drawing/human typing this ascii art
+	// unlike "interpreted language" 🤪
+	G: {
+		_G,
+		_O,
+		_GEN,
+		A_,
+		I_,
+	},
+	V: {
+		BLANK_,
+		BLANK_,
+		BLANK_, // TODO: Implement a notification to display here when a new version is available.
+		//			 For checking the version and viewing the change log, implement the command ":checkversion".
+		Current_Version,
+		Copyright,
+	},
+}
+
+// Define a map for character colors
+var asciiColors = map[rune]string{
+	G: BoldText + colors.ColorHex95b806,
+	V: BoldText + colors.ColorCyan24Bit,
+}
+
 // scalable a global variable for the ASCII slant style.
 var slantStyle = NewASCIIArtStyle()
 


### PR DESCRIPTION
- [+] chore(terminal): refactor ASCII art and text constants
- [+] - Move ASCII art patterns and colors from figlet_frontend.go to constant.go
- [+] - Remove unused code from figlet_frontend.go