### PR TITLE
Deprecated AsciiPatterns variable

### DIFF
--- a/terminal/deprecated.go
+++ b/terminal/deprecated.go
@@ -124,3 +124,28 @@ func HandleUnrecognizedCommand(command string, session *Session, parts []string)
 
 // Deprecated: This method is no longer used, and was replaced by SafetyOption.
 type SafetySetter func(*SafetySettings)
+
+// Define the ASCII patterns for the 'slant' font for the characters
+//
+// Deprecated: This variable is no longer used, and was replaced by NewASCIIArtStyle().
+var AsciiPatterns = map[rune][]string{
+	// Figlet in a compiled language, not an interpreted language.
+	// This literally header in your machine lmao.
+	// It so easy implement Header like this in go, also it possible to made it animated drawing/human typing this ascii art
+	// unlike "interpreted language" 🤪
+	G: {
+		_G,
+		_O,
+		_GEN,
+		A_,
+		I_,
+	},
+	V: {
+		BLANK_,
+		BLANK_,
+		BLANK_, // TODO: Implement a notification to display here when a new version is available.
+		//			 For checking the version and viewing the change log, implement the command ":checkversion".
+		Current_Version,
+		Copyright,
+	},
+}

--- a/terminal/init.go
+++ b/terminal/init.go
@@ -93,29 +93,6 @@ var safetyOptions = map[string]SafetyOption{
 	},
 }
 
-// Define the ASCII patterns for the 'slant' font for the characters
-var asciiPatterns = map[rune][]string{
-	// Figlet in a compiled language, not an interpreted language.
-	// This literally header in your machine lmao.
-	// It so easy implement Header like this in go, also it possible to made it animated drawing/human typing this ascii art
-	// unlike "interpreted language" 🤪
-	G: {
-		_G,
-		_O,
-		_GEN,
-		A_,
-		I_,
-	},
-	V: {
-		BLANK_,
-		BLANK_,
-		BLANK_, // TODO: Implement a notification to display here when a new version is available.
-		//			 For checking the version and viewing the change log, implement the command ":checkversion".
-		Current_Version,
-		Copyright,
-	},
-}
-
 // Define a map for character colors
 var asciiColors = map[rune]string{
 	G: BoldText + colors.ColorHex95b806,


### PR DESCRIPTION
- [+] refactor(deprecated.go): Remove deprecated variables and methods related to ASCII patterns and SafetySetter
- [+] refactor(init.go): Remove deprecated variables related to ASCII patterns and asciiColors