### PR TITLE
Deprecated AsciiColors variable

### DIFF
--- a/terminal/deprecated.go
+++ b/terminal/deprecated.go
@@ -149,3 +149,11 @@ var AsciiPatterns = map[rune][]string{
 		Copyright,
 	},
 }
+
+// Define a map for character Ascii colors
+//
+// Deprecated: This variable is no longer used, and was replaced by NewASCIIArtStyle().
+var AsciiColors = map[rune]string{
+	G: BoldText + colors.ColorHex95b806,
+	V: BoldText + colors.ColorCyan24Bit,
+}

--- a/terminal/init.go
+++ b/terminal/init.go
@@ -93,12 +93,6 @@ var safetyOptions = map[string]SafetyOption{
 	},
 }
 
-// Define a map for character colors
-var asciiColors = map[rune]string{
-	G: BoldText + colors.ColorHex95b806,
-	V: BoldText + colors.ColorCyan24Bit,
-}
-
 // scalable a global variable for the ASCII slant style.
 var slantStyle = NewASCIIArtStyle()
 


### PR DESCRIPTION
- [+] refactor(deprecated.go): remove deprecated AsciiColors variable
- [+] refactor(init.go): remove unused asciiColors variable
- [+] feat(deprecated.go): add comment explaining deprecation of AsciiColors variable