### PR TITLE
Improve ChatHistory in RAM's labyrinth

### DIFF
--- a/terminal/session.go
+++ b/terminal/session.go
@@ -21,7 +21,7 @@ import (
 // It holds the AI client, chat history, and context for managing the session lifecycle.
 type Session struct {
 	Client      *genai.Client      // Client is the generative AI client used to communicate with the AI model.
-	ChatHistory ChatHistory        // ChatHistory stores the history of the chat session.
+	ChatHistory *ChatHistory       // ChatHistory stores the history of the chat session.
 	Ctx         context.Context    // Ctx is the context governing the session, used for cancellation.
 	Cancel      context.CancelFunc // Cancel is a function to cancel the context, used for cleanup.
 	Ended       bool               // Ended indicates whether the session has ended.
@@ -65,9 +65,11 @@ func NewSession(apiKey string) *Session {
 	}
 	// Note: This doesn't use a storage system like a database or file system to keep the chat history, nor does it use a JSON structure (as a front-end might) for sending request to Google AI.
 	// So if you're wondering where this is all stored, it's in a place you won't find—somewhere in the RAM's labyrinth, hahaha!
+	// Initialize the ChatHistory here instead of using an empty struct
+	chatHistory := NewChatHistory() // Hash RAM's labyrinth, hahaha!
 	return &Session{
 		Client:      client,
-		ChatHistory: ChatHistory{},
+		ChatHistory: chatHistory, // Store the pointer to ChatHistory in RAM's labyrinth
 		Ctx:         ctx,
 		Cancel:      cancel,
 	}


### PR DESCRIPTION
- [+] feat(terminal/chat.go): add support for hashing messages in ChatHistory
- [+] feat(terminal/chat.go): add support for storing message hashes in ChatHistory
- [+] feat(terminal/chat.go): add support for locking ChatHistory for concurrent access
- [+] feat(terminal/chat.go): add NewChatHistory function to initialize ChatHistory
- [+] feat(terminal/chat.go): update AddMessage method to use message hashing and locking
- [+] feat(terminal/chat.go): update GetHistory method to use locking
- [+] feat(terminal/chat.go): add hashMessage method to generate hash for messages
- [+] feat(terminal/chat.go): update RemoveMessages method to use locking and remove message hashes
- [+] feat(terminal/chat.go): update removeMessagesByContent method to remove message hashes
- [+] feat(terminal/chat.go): update removeRecentMessages method to remove message hashes
- [+] feat(terminal/chat.go): add min function to get the smaller of two numbers
- [+] feat(terminal/chat.go): add FilterMessages method to filter messages based on predicate
- [+] feat(terminal/chat.go): update Clear method to remove message hashes
- [+] feat(terminal/session.go): update ChatHistory field in Session struct to be a pointer
- [+] feat(terminal/session.go): initialize ChatHistory in NewSession function