### PR TITLE
Deprecated: IsLastMessage

### DIFF
--- a/terminal/chat.go
+++ b/terminal/chat.go
@@ -185,11 +185,6 @@ func isSysMessage(message string) bool {
 	return strings.HasPrefix(message, SYSTEMPREFIX)
 }
 
-// isLastMessage checks if the current index is the last message in the slice
-func isLastMessage(index int, messages []string) bool {
-	return index == len(messages)-1
-}
-
 // hashMessage generates a SHA-256 hash for a given message.
 func (h *ChatHistory) hashMessage(message string) string {
 	hasher := sha256.New()

--- a/terminal/deprecated.go
+++ b/terminal/deprecated.go
@@ -178,3 +178,10 @@ func ReplaceTripleBackticks(text, placeholder string) string {
 	}
 	return text
 }
+
+// IsLastMessage checks if the current index is the last message in the slice
+//
+// Deprecated: This method is no longer used, and was replaced by separateSystemMessages
+func IsLastMessage(index int, messages []string) bool {
+	return index == len(messages)-1
+}


### PR DESCRIPTION
- [+] refactor(chat.go): remove unused isLastMessage function
- [+] docs(deprecated.go): deprecate IsLastMessage function, replaced by separateSystemMessages
