### PR TITLE
fix SYSTEMPREFIX formatting

### DIFF
--- a/terminal/constant.go
+++ b/terminal/constant.go
@@ -233,7 +233,7 @@ const (
 // Defined Prefix System
 const (
 	// Note: This is a prefix for the system
-	SYSTEMPREFIX     = "⚙️  SYSTEM:"
+	SYSTEMPREFIX     = "⚙️ SYSTEM:"
 	SystemSafety     = "Safety level set to " + ColorHex95b806 + "%s" + ColorReset + "."
 	Low              = "low"
 	Default          = "default"


### PR DESCRIPTION
> [!WARNING]  
> use a better `terminal` that can handle a `constant` in this repository or build your own os that can handle `constant` in this repository