### PR TITLE
Implement [Terminal] [Front End] "isFirstCharacterWide"

### DIFF
--- a/terminal/constant.go
+++ b/terminal/constant.go
@@ -19,6 +19,7 @@ const (
 	SignalMessage                    = " Received an interrupt, shutting down gracefully..." // fix formatting ^C in linux/unix
 	RecoverGopher                    = "%sRecovered from panic:%s %s%v%s"
 	ObjectHighLevelString            = "%s %s"   // Catch High level string
+	ObjectHighLevelStringWithSpace   = "%s %s "  // Catch High level string with space
 	ObjectHighLevelStringWithNewLine = "%s %s\n" // Catch High level string With NewLine
 	ObjectTripleHighLevelString      = "%%%s%%"  // Catch High level triple string
 	ObjectHighLevelContextString     = "%s\n%s"  // Catch High level context string

--- a/terminal/front_end.go
+++ b/terminal/front_end.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	genai "github.com/google/generative-ai-go/genai"
 )
@@ -52,7 +53,25 @@ func FilterLanguageFromCodeBlock(text string) string {
 // or any other string that aids in categorizing or highlighting the message.
 func PrintPrefixWithTimeStamp(prefix string) {
 	currentTime := time.Now().Format(TimeFormat)
-	fmt.Printf(ObjectHighLevelString+" ", currentTime, prefix)
+	// Check if the first character is potentially an emoji or wide character.
+	if isFirstCharacterWide(prefix) {
+		// Add an extra space after the prefix to ensure separation in terminals that might not handle wide characters well.
+		fmt.Printf(ObjectHighLevelStringWithSpace, currentTime, prefix)
+	} else {
+		fmt.Printf(ObjectHighLevelString, currentTime, prefix)
+	}
+}
+
+// isFirstCharacterWide checks if the first character of the string is wider than a standard character.
+// This is a simple heuristic based on the assumption that most emojis and wide characters
+// have a UTF-8 encoded length greater than 1. This won't cover all cases but works for many emojis.
+func isFirstCharacterWide(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	_, size := utf8.DecodeRuneInString(s)
+	// Assuming characters with a UTF-8 size greater than 1 are wide (e.g., most emojis).
+	return size > 1
 }
 
 // printPromptFeedback formats and prints the prompt feedback received from the AI.


### PR DESCRIPTION
- [+] fix(terminal/constant.go): add constant for high level string with space
- [+] feat(terminal/front_end.go): add function to check if first character is wide

Note: This update may resolve an issue experienced when running this Rich Terminal Interface Chat on certain terminals or operating systems that struggle with handling emojis or constants (bad os/terminal), as defined in this repository.
