### PR TITLE
Fix Bug Can't Clear Chat History

### DIFF
--- a/terminal/commands.go
+++ b/terminal/commands.go
@@ -192,8 +192,8 @@ func (h *handleHelpCommand) Execute(session *Session, parts []string) (bool, err
 		ChatHistoryArgs,
 		ClearCommand,
 		SummarizeCommands,
+		ChatCommands,
 		ClearCommand,
-		ChatHistoryArgs,
 	)
 
 	// Sanitize the message before sending it to the AI

--- a/terminal/commands_types.go
+++ b/terminal/commands_types.go
@@ -128,9 +128,7 @@ type handleClearCommand struct{}
 //
 // Returns true if the command is valid, otherwise false.
 func (cmd *handleClearCommand) IsValid(parts []string) bool {
-	// Combine the parts after the command keyword to match the ClearChatHistoryArgs
-	args := strings.Join(parts[1:], " ")
-	return len(parts) > 1 && args == ChatHistoryArgs
+	return len(parts) == 2 && parts[0] == ChatCommands && parts[1] == ClearCommand
 }
 
 // handleSafetyCommand is the command to adjust safety settings.
@@ -216,7 +214,7 @@ type handleClearAllSystemMessagesCommand struct{}
 // IsValid checks if the clear system messages command is valid based on the input parts.
 // This command is valid only if it exactly matches ":clear :summarize".
 func (cmd *handleClearAllSystemMessagesCommand) IsValid(parts []string) bool {
-	return len(parts) == 2 && parts[0] == ClearCommand && parts[1] == SummarizeCommands
+	return len(parts) == 2 && parts[0] == SummarizeCommands && parts[1] == SummarizeCommands
 }
 
 // Note: this unimplemented

--- a/terminal/constant.go
+++ b/terminal/constant.go
@@ -118,7 +118,7 @@ const (
 	CryptoRandCommand  = ":cryptorand"
 	LengthArgs         = ":length"
 	ShowCommands       = ":show"
-	ChatArgs           = ":chat"
+	ChatCommands       = ":chat"
 	SummarizeCommands  = ":summarize"
 	ClearCommand       = ":clear"
 	PingCommand        = ":ping" // Currently marked as TODO

--- a/terminal/init.go
+++ b/terminal/init.go
@@ -124,7 +124,7 @@ func init() {
 	registry.Register(VersionCommand, &handleCheckVersionCommand{})
 	registry.Register(HelpCommand, &handleHelpCommand{})
 	registry.Register(ShortHelpCommand, &handleHelpCommand{})
-	registry.Register(ClearCommand, &handleClearCommand{})
+	registry.Register(ChatCommands, &handleClearCommand{})
 	registry.Register(SafetyCommand, &handleSafetyCommand{})
 	registry.Register(AITranslateCommand, &handleAITranslateCommand{})
 	registry.Register(CryptoRandCommand, &handleCryptoRandCommand{})


### PR DESCRIPTION
- [+] fix(terminal/commands.go): add ChatCommands to the list of commands
- [+] fix(terminal/commands.go): remove ChatHistoryArgs from the list of commands
- [+] fix(terminal/commands_types.go): update IsValid function for handleClearCommand
- [+] fix(terminal/commands_types.go): update IsValid function for handleClearAllSystemMessagesCommand
- [+] fix(terminal/constant.go): change ChatArgs constant to ChatCommands
- [+] fix(terminal/init.go): update registry.Register for ClearCommand to use ChatCommands
