### PR TITLE
Simplify ExecuteCommand method to avoid complexity overhead

### DIFF
--- a/terminal/commands.go
+++ b/terminal/commands.go
@@ -285,9 +285,6 @@ func (cmd *handleClearCommand) Execute(session *Session, parts []string) (bool, 
 	// But let's cross that bridge when we get to it. For now, we revel in the simplicity of our logic. Stay tuned, fellow code whisperers! 😜
 
 	// Note: This place only, for commands doesn't have any subcommands/args, so it will return error hahaha
-
-	// Log the error if the command is not valid
-	logger.Error(HumanErrorWhileTypingCommandArgs, parts)
 	return false, nil // Continue the session
 }
 

--- a/terminal/constant.go
+++ b/terminal/constant.go
@@ -154,7 +154,7 @@ const (
 	HumanErrorWhileTypingCommandArgs                = "Invalid Command Arguments: %v"
 	ErrorPingFailed                                 = "Ping failed: %v"
 	ErrorUnrecognizedCommand                        = "Unrecognized command: %s"
-	ErrorUnrecognizedSubCommand                     = "Unrecognized %s command sub commands: %s"
+	ErrorUnrecognizedSubCommand                     = "Unrecognized %s command sub commands/args : %s"
 	ErrorLowLevelCommand                            = "command cannot be empty"
 	ErrorUnknown                                    = "An error occurred: %v"
 	ErrorUnknownSafetyLevel                         = "Unknown safety level: %s"

--- a/terminal/constant.go
+++ b/terminal/constant.go
@@ -154,6 +154,7 @@ const (
 	HumanErrorWhileTypingCommandArgs                = "Invalid Command Arguments: %v"
 	ErrorPingFailed                                 = "Ping failed: %v"
 	ErrorUnrecognizedCommand                        = "Unrecognized command: %s"
+	ErrorUnrecognizedSubCommand                     = "Unrecognized %s command sub commands: %s"
 	ErrorLowLevelCommand                            = "command cannot be empty"
 	ErrorUnknown                                    = "An error occurred: %v"
 	ErrorUnknownSafetyLevel                         = "Unknown safety level: %s"


### PR DESCRIPTION
- [+] refactor(commands_types.go): simplify ExecuteCommand method in CommandRegistry
- [+] fix(constant.go): add error message for unrecognized sub commands
