### PR TITLE
Fix ShowChatCommand

### DIFF
--- a/terminal/commands.go
+++ b/terminal/commands.go
@@ -454,16 +454,20 @@ func (h *handleCryptoRandCommand) HandleSubcommand(subcommand string, session *S
 //
 // Returns false to indicate the session should continue, and an error if there is an issue.
 func (cmd *handleShowChatCommand) Execute(session *Session, parts []string) (bool, error) {
+	// Return false to indicate the session should continue.
+	return false, nil
+}
+
+func (cmd *handleShowChatCommand) HandleSubcommand(subcommand string, session *Session, parts []string) (bool, error) {
 	if !cmd.IsValid(parts) {
 		logger.Error(HumanErrorWhileTypingCommandArgs, parts)
 		fmt.Println()
-		return true, nil
+		return false, nil
 	}
 
 	// Retrieve and log the entire chat history.
 	history := session.ChatHistory.GetHistory(session.ChatConfig)
 	logger.Info(ShowChatHistory, history)
-
 	return false, nil // Return false to indicate the session should continue.
 }
 

--- a/terminal/commands_types.go
+++ b/terminal/commands_types.go
@@ -294,11 +294,6 @@ func (cmd *handleCryptoRandCommand) IsValid(parts []string) bool {
 // handleChatShowCommand is responsible for executing the ":show chat history" command.
 type handleShowChatCommand struct{}
 
-func (h *handleShowChatCommand) HandleSubcommand(subcommand string, session *Session, parts []string) (bool, error) {
-	// unimplemented
-	return true, nil
-}
-
 // IsValid checks if the chat show command is valid based on the input parts.
 // The chat show command is valid only if there are no additional arguments, hence
 // the length of parts must be exactly 1.
@@ -308,8 +303,8 @@ func (h *handleShowChatCommand) HandleSubcommand(subcommand string, session *Ses
 // Returns true if the command is valid, otherwise false.
 func (cmd *handleShowChatCommand) IsValid(parts []string) bool {
 	// Combine the parts after the command keyword to match the ChatHistoryArgs
-	args := strings.Join(parts[1:], " ")
-	return len(parts) > 1 && args == ChatHistoryArgs
+	args := strings.Join(parts[2:], " ")
+	return len(parts) > 2 && args == ChatHistoryArgs
 }
 
 // handleSummarizeCommand executes the ":summarize" command.

--- a/terminal/constant.go
+++ b/terminal/constant.go
@@ -125,7 +125,7 @@ const (
 	PingCommand        = ":ping" // Currently marked as TODO
 	PrefixChar         = ":"
 	// List args
-	ChatHistoryArgs = "chat history"
+	ChatHistoryArgs = "history"
 )
 
 // Defined List error message

--- a/terminal/init.go
+++ b/terminal/init.go
@@ -125,7 +125,6 @@ func init() {
 	registry.Register(HelpCommand, &handleHelpCommand{})
 	registry.Register(ShortHelpCommand, &handleHelpCommand{})
 	registry.Register(AITranslateCommand, &handleAITranslateCommand{})
-	registry.Register(ShowCommands, &handleShowChatCommand{})
 	registry.Register(SummarizeCommands, &handleSummarizeCommand{})
 	// Assume handleClearCommand is capable of handling subcommands for ":clear"
 	clearCommandHandler := &handleClearCommand{}
@@ -148,6 +147,10 @@ func init() {
 	registry.RegisterSubcommand(SafetyCommand, Low, safetySettingsCommandHandler)
 	registry.RegisterSubcommand(SafetyCommand, Default, safetySettingsCommandHandler)
 	registry.RegisterSubcommand(SafetyCommand, High, safetySettingsCommandHandler)
+	// Assume showChatCommandHandler is capable of handling subcommands for ":chat"
+	showChatCommandHandler := &handleShowChatCommand{}
+	registry.Register(ChatCommands, &handleShowChatCommand{})
+	registry.RegisterSubcommand(ChatCommands, ShowCommands, showChatCommandHandler)
 
 	//TODO: Will add more commands here, example: :help, :about, :credits, :k8s, syncing AI With Go Routines (Known as Gopher hahaha) etc.
 	// Note: In python, I don't think so it's possible hahaahaha, also I am using prefix ":" instead of "/" is respect to git and command line, fuck prefix "/" which is confusing for command line


### PR DESCRIPTION
- [+] fix(commands.go): fix return value in handleShowChatCommand.Execute method
- [+] fix(commands.go): fix return value in handleShowChatCommand.HandleSubcommand method
- [+] fix(commands_types.go): fix argument index in handleShowChatCommand.IsValid method
- [+] fix(constant.go): fix ChatHistoryArgs constant value
- [+] fix(init.go): remove duplicate registration of handleShowChatCommand and register subcommands for ChatCommands
