### PR TITLE
Fix [Terminal] [Retry Policy] for handling other API errors

### DIFF
--- a/terminal/retry_policy.go
+++ b/terminal/retry_policy.go
@@ -57,3 +57,9 @@ func standardAPIErrorHandler(err error) bool {
 	// Error 500 Google Api
 	return strings.Contains(err.Error(), Error500GoogleApi)
 }
+
+// standardAPIErrorHandler is the standard error handling strategy for API errors.
+func standardOtherAPIErrorHandler(err error) bool {
+	// Error 500 Other Api
+	return strings.Contains(err.Error(), Code500)
+}


### PR DESCRIPTION
- [+] fix(terminal/release.go): remove unused import of "strings"
- [+] fix(terminal/release.go): change apiErrorHandler to standardOtherAPIErrorHandler
- [+] fix(terminal/retry_policy.go): add standardOtherAPIErrorHandler for handling other API errors
