### PR TITLE
Update [Terminal] [Constant] ItalicTextRegex

### DIFF
--- a/terminal/constant.go
+++ b/terminal/constant.go
@@ -225,20 +225,21 @@ const (
 
 // Defined List of characters
 const (
-	SingleAsterisk          = "*"
-	DoubleAsterisk          = "**"
-	SingleBacktick          = "`"
-	TripleBacktick          = "```"
-	SingleUnderscore        = "_"
-	StringNewLine           = "\n"
-	BinaryAnsiChar          = '\x1b'
-	BinaryLeftSquareBracket = '['
-	BinaryAnsiSquenseChar   = 'm'
-	BinaryAnsiSquenseString = "m"
-	BinaryRegexAnsi         = `\x1b\[[0-9;]*m`
-	CodeBlockRegex          = "```\\w+"
-	SanitizeTextAIResponse  = "\n---\n"
-	ItalicTextRegex         = `\*([^\s][^\*]*?[^\s])\*`
+	SingleAsterisk                     = "*"
+	DoubleAsterisk                     = "**"
+	SingleBacktick                     = "`"
+	TripleBacktick                     = "```"
+	SingleUnderscore                   = "_"
+	StringNewLine                      = "\n"
+	BinaryAnsiChar                     = '\x1b'
+	BinaryLeftSquareBracket            = '['
+	BinaryAnsiSquenseChar              = 'm'
+	BinaryAnsiSquenseString            = "m"
+	BinaryRegexAnsi                    = `\x1b\[[0-9;]*m`
+	CodeBlockRegex                     = "```\\w+"
+	SanitizeTextAIResponse             = "\n---\n"
+	ItalicTextRegex                    = `\*(\S(.*?\S)?)\*`   // Updated regex to match text surrounded by single asterisks
+	StandaloneAsteriskAnsiRegexPattern = `(?m)(^|\s)\*(\s|$)` // TODO
 )
 
 // Defined List of Environment variables


### PR DESCRIPTION
- [+] feat(constant.go): update ItalicTextRegex and add StandaloneAsteriskAnsiRegexPattern constant

Note: By Updating `ItalicTextRegex` it now support ***bold italicized text***
