### PR TITLE
Fix [Terminal] [Command Tools] Correct Validation for CryptoRand

### DIFF
--- a/terminal/commands.go
+++ b/terminal/commands.go
@@ -288,6 +288,12 @@ func (cmd *handleCryptoRandCommand) Execute(session *Session, parts []string) (b
 }
 
 func (cmd *handleCryptoRandCommand) HandleSubcommand(subcommand string, session *Session, parts []string) (bool, error) {
+	// Check if there are enough parts to contain the length argument.
+	if len(parts) < 3 {
+		logger.Error(ErrorWhileTypingCommandArgs, subcommand, parts)
+		return false, nil
+	}
+
 	lengthStr := parts[2] // The length argument is now the second part of the command
 	length, err := strconv.Atoi(lengthStr)
 	if err != nil {

--- a/terminal/commands_types.go
+++ b/terminal/commands_types.go
@@ -299,7 +299,7 @@ type handleCryptoRandCommand struct{}
 // The cryptorand command is expected to follow the pattern: :cryptorand :length <number>
 func (cmd *handleCryptoRandCommand) IsValid(parts []string) bool {
 	// The cryptorand command should have exactly two parts: the command itself and the length argument.
-	return len(parts) == 1
+	return len(parts) == 2
 }
 
 // handleChatShowCommand is responsible for executing the ":show chat history" command.


### PR DESCRIPTION
- [+] fix(terminal): correct validation for cryptorand command length
- [+] feat(terminal): add error logging for insufficient cryptorand command arguments
