### PR TITLE
Fix [Terminal] [AI Stuff] [DisplayModelInfo] Remove BaseModelID

### DIFF
--- a/terminal/ai_stuff.go
+++ b/terminal/ai_stuff.go
@@ -331,7 +331,6 @@ func DisplayModelInfo(info *genai.ModelInfo) {
 	modelInfo := fmt.Sprintf(
 		ModelFormat,
 		info.DisplayName,
-		info.BaseModelID, // Note: this not showing could be a bug, in google sdk side
 		info.Version,
 		info.Description,
 		info.SupportedGenerationMethods,

--- a/terminal/constant.go
+++ b/terminal/constant.go
@@ -311,7 +311,6 @@ const (
 		" attempt number " + ColorHex95b806 + BoldText + "%d" + ResetBoldText + ColorReset
 	// ModelFormat defines a template for displaying model information with color and bold formatting for placeholders.
 	ModelFormat = "Model Name: " + ColorHex95b806 + BoldText + "%s" + ResetBoldText + ColorReset + "\n" +
-		"Model ID: " + ColorHex95b806 + BoldText + "%s" + ResetBoldText + ColorReset + "\n" +
 		"Version: " + ColorHex95b806 + BoldText + "%s" + ResetBoldText + ColorReset + "\n" +
 		"Description: " + ColorHex95b806 + BoldText + "%s" + ResetBoldText + ColorReset + "\n" +
 		"Supported Generation Methods: " + ColorHex95b806 + BoldText + "%s" + ResetBoldText + ColorReset + "\n" +


### PR DESCRIPTION
- [+] fix(ai_stuff.go, constant.go): remove BaseModelID from DisplayModelInfo function and ModelFormat constant

Reason: not showing as expected
